### PR TITLE
fix: all messages of observation and action_applied now inputs to ren…

### DIFF
--- a/eagerx_ode/engine_nodes.py
+++ b/eagerx_ode/engine_nodes.py
@@ -209,10 +209,8 @@ class OdeRender(EngineNode):
         self, t_n: float, tick: Msg = None, observation: Float32MultiArray = None, action_applied: Float32MultiArray = None
     ):
         if self.render_toggle:
-            observation = np.array(observation.msgs[-1].data)
-            action = np.array(action_applied.msgs[-1].data)
             img = np.zeros((self.shape[0], self.shape[1], 3), np.uint8)
-            img = self.render_fn(img, observation, action)
+            img = self.render_fn(img, observation, action_applied)
             try:
                 msg = self.cv_bridge.cv2_to_imgmsg(img, "bgr8")
             except ImportError as e:

--- a/tests/pendulum/objects.py
+++ b/tests/pendulum/objects.py
@@ -136,7 +136,7 @@ class Pendulum(Object):
         graph.add([obs, image, action])
         graph.connect(source=obs.outputs.observation, sensor="pendulum_output")
         graph.connect(actuator="pendulum_input", target=action.inputs.action)
-        graph.connect(source=action.outputs.action_applied, target=image.inputs.action_applied)
+        graph.connect(source=action.outputs.action_applied, target=image.inputs.action_applied, skip=True)
         graph.connect(source=obs.outputs.observation, target=image.inputs.observation)
         graph.connect(source=image.outputs.image, sensor="image")
 

--- a/tests/pendulum/pendulum_render.py
+++ b/tests/pendulum/pendulum_render.py
@@ -4,7 +4,7 @@ import numpy as np
 
 def pendulum_render_fn(img, observation, action):
     height, width, _ = img.shape
-    state = observation
+    state = observation.msgs[-1].data
 
     l = width // 3
     sin_theta, cos_theta = np.sin(state[0]), np.cos(state[0])


### PR DESCRIPTION
…der_fn

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix OdeRender: render_fn now gets the list of observation and action_applied as argument instead of last.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->
- [x] I have raised an issue to propose this change ([required](https://github.com/eager-dev/eagerx/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTION](https://github.com/eager-dev/eagerx/blob/master/CONTRIBUTING.rst) guide (**required**).
- [ ] I have used semantic commit messages such that my PR is [semantic](https://github.com/zeke/semantic-pull-requests) (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make codestyle` (**required**).
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**).
- [x] I have ensured `make pytest` passes. (**required**).

Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3 which is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
